### PR TITLE
deixando o arquivo índice.html mais enxuto

### DIFF
--- a/assets/css/cabecalho_principal/cabecalho_principal.css
+++ b/assets/css/cabecalho_principal/cabecalho_principal.css
@@ -1,3 +1,10 @@
+@import url('cabecalho_principal-lista.css');
+@import url('cabecalho_principal-link-0.css');
+@import url('cabecalho_principal-link-1.css');
+@import url('cabecalho_principal-link-2.css');
+@import url('cabecalho_principal-link-3.css');
+@import url('cabecalho_principal-link-4.css');
+@import url('cabecalho_principal-item.css');
 .cabecalho_principal {
     display: flex;
     flex-direction: column;

--- a/assets/css/conhecimentos/conhecimentos.css
+++ b/assets/css/conhecimentos/conhecimentos.css
@@ -1,3 +1,7 @@
+@import url('conhecimentos-titulo.css');
+@import url('conhecimentos-lista.css');
+@import url('conhecimentos-item.css');
+@import url('conhecimentos-logo.css');
 .conhecimentos {
     display: flex;
     flex-direction: column;

--- a/assets/css/container_titulo/container_titulo.css
+++ b/assets/css/container_titulo/container_titulo.css
@@ -1,3 +1,5 @@
+@import url('container_titulo-principal.css');
+@import url('container_titulo-imagem.css');
 .container_titulo {
     width: 100vw;
     display: flex;

--- a/assets/css/contatos/contatos.css
+++ b/assets/css/contatos/contatos.css
@@ -1,3 +1,8 @@
+@import url('contatos-titulo.css');
+@import url('contatos-lista.css');
+@import url('contatos-link.css');
+@import url('contatos-item.css');
+@import url('contatos-logo.css');
 .contatos {
     display: flex;
     flex-direction: column;

--- a/assets/css/dados_pessoais/dados_pessoais.css
+++ b/assets/css/dados_pessoais/dados_pessoais.css
@@ -1,3 +1,6 @@
+@import url('dados_pessoais-titulo.css');
+@import url('dados_pessoais-lista.css');
+@import url('dados_pessoais-item.css');
 .dados_pessoais {
     display: flex;
     flex-direction: column;

--- a/assets/css/formacao/formacao.css
+++ b/assets/css/formacao/formacao.css
@@ -1,3 +1,6 @@
+@import url('formacao-titulo.css');
+@import url('formacao-lista.css');
+@import url('formacao-item.css');
 .formacao {
     display: flex;
     flex-direction: column;

--- a/assets/css/resumo/resumo.css
+++ b/assets/css/resumo/resumo.css
@@ -1,0 +1,6 @@
+@import url('resumo-titulo.css');
+@import url('resumo-conteudo.css');
+.resumo {
+    display: flex;
+    flex-direction: column;
+}

--- a/assets/css/rodape/rodape.css
+++ b/assets/css/rodape/rodape.css
@@ -1,3 +1,6 @@
+@import url('rodape-lista.css');
+@import url('rodape-item.css');
+@import url('rodape-imagem.css');
 .rodape {
     display: flex;
     background: #1a1a1f;

--- a/index.html
+++ b/index.html
@@ -12,43 +12,15 @@
     <link rel="stylesheet" href="assets/css/normalize.css">
     <link rel="stylesheet" href="assets/css/body.css">
     <link rel="stylesheet" href="assets/css/container_titulo/container_titulo.css">
-    <link rel="stylesheet" href="assets/css/container_titulo/container_titulo-principal.css">
-    <link rel="stylesheet" href="assets/css/container_titulo/container_titulo-imagem.css">
     <link rel="stylesheet" href="assets/css/cabecalho_principal/cabecalho_principal.css">
-    <link rel="stylesheet" href="assets/css/cabecalho_principal/cabecalho_principal-lista.css">
-    <link rel="stylesheet" href="assets/css/cabecalho_principal/cabecalho_principal-link-0.css">
-    <link rel="stylesheet" href="assets/css/cabecalho_principal/cabecalho_principal-link-1.css">
-    <link rel="stylesheet" href="assets/css/cabecalho_principal/cabecalho_principal-link-2.css">
-    <link rel="stylesheet" href="assets/css/cabecalho_principal/cabecalho_principal-link-3.css">
-    <link rel="stylesheet" href="assets/css/cabecalho_principal/cabecalho_principal-link-4.css">
-    <link rel="stylesheet" href="assets/css/cabecalho_principal/cabecalho_principal-item.css">
     <link rel="stylesheet" href="assets/css/conteudo.css">
     <link rel="stylesheet" href="assets/css/container.css">
     <link rel="stylesheet" href="assets/css/dados_pessoais/dados_pessoais.css">
-    <link rel="stylesheet" href="assets/css/dados_pessoais/dados_pessoais-titulo.css">
-    <link rel="stylesheet" href="assets/css/dados_pessoais/dados_pessoais-lista.css">
-    <link rel="stylesheet" href="assets/css/dados_pessoais/dados_pessoais-item.css">
-    <link rel="stylesheet" href="assets/css/resumo/resumo-titulo.css">
-    <link rel="stylesheet" href="assets/css/resumo/resumo-conteudo.css">
+    <link rel="stylesheet" href="assets/css/resumo/resumo.css">
     <link rel="stylesheet" href="assets/css/conhecimentos/conhecimentos.css">
-    <link rel="stylesheet" href="assets/css/conhecimentos/conhecimentos-titulo.css">
-    <link rel="stylesheet" href="assets/css/conhecimentos/conhecimentos-lista.css">
-    <link rel="stylesheet" href="assets/css/conhecimentos/conhecimentos-item.css">
-    <link rel="stylesheet" href="assets/css/conhecimentos/conhecimentos-logo.css">
     <link rel="stylesheet" href="assets/css/contatos/contatos.css">
-    <link rel="stylesheet" href="assets/css/contatos/contatos-titulo.css">
-    <link rel="stylesheet" href="assets/css/contatos/contatos-lista.css">
-    <link rel="stylesheet" href="assets/css/contatos/contatos-item.css">
-    <link rel="stylesheet" href="assets/css/contatos/contatos-link.css">
-    <link rel="stylesheet" href="assets/css/contatos/contatos-logo.css">
     <link rel="stylesheet" href="assets/css/formacao/formacao.css">
-    <link rel="stylesheet" href="assets/css/formacao/formacao-titulo.css">
-    <link rel="stylesheet" href="assets/css/formacao/formacao-lista.css">
-    <link rel="stylesheet" href="assets/css/formacao/formacao-item.css">
     <link rel="stylesheet" href="assets/css/rodape/rodape.css">
-    <link rel="stylesheet" href="assets/css/rodape/rodape-lista.css">
-    <link rel="stylesheet" href="assets/css/rodape/rodape-item.css">
-    <link rel="stylesheet" href="assets/css/rodape/rodape-imagem.css">
 </head>
 
 <body>


### PR DESCRIPTION
Foi removido links css do arquivo html para deixa-lo mais enxuto e menos repetível, e para diminuir o tamanho do código.
Os links css foram importados para seus arquivos css pais  